### PR TITLE
Fixes regex to recognise JDKs without .0 version

### DIFF
--- a/j.sh
+++ b/j.sh
@@ -11,7 +11,7 @@ function print_usage() {
 
 if [[ $# -eq 1 ]]; then
   VERSION_NUMBER=$1
-  IDENTIFIER=$(ls $SDKMAN_DIR/candidates/java | grep -v current | grep "$VERSION_NUMBER.0." | sort -r | head -n 1)
+  IDENTIFIER=$(ls $SDKMAN_DIR/candidates/java | grep -v current | grep "^$VERSION_NUMBER." | sort -r | head -n 1)
   sdk use java $IDENTIFIER
 else
   print_usage


### PR DESCRIPTION
This script assumes that all JDK's have a `major.0.patch` version number. This is true for many of them, and probably most of the ones that are used the most. But there are also JDK's like `15.ea.36` (in Java.net) and `20.2.0.r11` (in GraalVM). This fix makes sure that `j` can switch to those, too.