### PR TITLE
🐛 Fix bug by ignoring command aliases

### DIFF
--- a/j.sh
+++ b/j.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
 
 function print_usage() {
-    VERSIONS=$(ls $SDKMAN_DIR/candidates/java | grep -v current | awk -F'.' '{print $1}' | sort -nr | uniq)
-    CURRENT=$(basename $(readlink $JAVA_HOME || echo $JAVA_HOME) | awk -F'.' '{print $1}')
-    echo "Available versions: "
-    echo "$VERSIONS"
-    echo "Current: $CURRENT"
-    echo "Usage: j <java_version>"
+    VERSIONS=$(\ls $SDKMAN_DIR/candidates/java | \grep -v current | \awk -F'.' '{print $1}' | \sort -nr | \uniq)
+    CURRENT=$(\basename $(\readlink $JAVA_HOME || \echo $JAVA_HOME) | \awk -F'.' '{print $1}')
+    \echo "Available versions: "
+    \echo "$VERSIONS"
+    \echo "Current: $CURRENT"
+    \echo "Usage: j <java_version>"
 }
 
 if [[ $# -eq 1 ]]; then
   VERSION_NUMBER=$1
-  IDENTIFIER=$(ls $SDKMAN_DIR/candidates/java | grep -v current | grep "^$VERSION_NUMBER." | sort -r | head -n 1)
+  IDENTIFIER=$(\ls $SDKMAN_DIR/candidates/java | \grep -v current | \grep "^$VERSION_NUMBER." | \sort -r | \head -n 1)
   sdk use java $IDENTIFIER
 else
   print_usage


### PR DESCRIPTION
The script might fail when the user has configured command aliases like `alias grep='grep -Hn'`. This alias is for example configured by default on Fedora Linux. The fix is very easy: Always call the command directly by ignoring the aliases. That's done by prefixing the command with a backslash (e.g. `\grep` instead of just `grep`).